### PR TITLE
Add Apache mod_remoteip configuration for proxy support

### DIFF
--- a/Containerfile.ubi10
+++ b/Containerfile.ubi10
@@ -8,6 +8,18 @@ RUN set -ex; \
     dnf -y clean all; \
     rm -rf /var/cache/dnf;
 
+# Configure Apache mod_remoteip for proper client IP handling behind proxies
+# https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
+RUN { \
+        echo 'RemoteIPHeader X-Forwarded-For'; \
+        echo '# Trust proxy IPs from private networks (Kubernetes/OpenShift)'; \
+        echo 'RemoteIPTrustedProxy 10.0.0.0/8'; \
+        echo 'RemoteIPTrustedProxy 172.16.0.0/12'; \
+        echo 'RemoteIPTrustedProxy 192.168.0.0/16'; \
+        echo 'RemoteIPTrustedProxy 169.254.0.0/16'; \
+        echo 'RemoteIPTrustedProxy 127.0.0.0/8'; \
+    } > /etc/httpd/conf.d/remoteip.conf
+
 # Install redis for PHP session handling and common caching
 # https://github.com/phpredis/phpredis/blob/develop/INSTALL.markdown
 RUN set -ex; \

--- a/Containerfile.ubi8
+++ b/Containerfile.ubi8
@@ -10,6 +10,18 @@ RUN set -ex; \
     dnf -y clean all; \
     rm -rf /var/cache/dnf;
 
+# Configure Apache mod_remoteip for proper client IP handling behind proxies
+# https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
+RUN { \
+        echo 'RemoteIPHeader X-Forwarded-For'; \
+        echo '# Trust proxy IPs from private networks (Kubernetes/OpenShift)'; \
+        echo 'RemoteIPTrustedProxy 10.0.0.0/8'; \
+        echo 'RemoteIPTrustedProxy 172.16.0.0/12'; \
+        echo 'RemoteIPTrustedProxy 192.168.0.0/16'; \
+        echo 'RemoteIPTrustedProxy 169.254.0.0/16'; \
+        echo 'RemoteIPTrustedProxy 127.0.0.0/8'; \
+    } > /etc/httpd/conf.d/remoteip.conf
+
 # Install redis for PHP session handling and common caching
 # https://github.com/phpredis/phpredis/blob/develop/INSTALL.markdown
 RUN set -ex; \

--- a/Containerfile.ubi9
+++ b/Containerfile.ubi9
@@ -8,6 +8,18 @@ RUN set -ex; \
     dnf -y clean all; \
     rm -rf /var/cache/dnf;
 
+# Configure Apache mod_remoteip for proper client IP handling behind proxies
+# https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
+RUN { \
+        echo 'RemoteIPHeader X-Forwarded-For'; \
+        echo '# Trust proxy IPs from private networks (Kubernetes/OpenShift)'; \
+        echo 'RemoteIPTrustedProxy 10.0.0.0/8'; \
+        echo 'RemoteIPTrustedProxy 172.16.0.0/12'; \
+        echo 'RemoteIPTrustedProxy 192.168.0.0/16'; \
+        echo 'RemoteIPTrustedProxy 169.254.0.0/16'; \
+        echo 'RemoteIPTrustedProxy 127.0.0.0/8'; \
+    } > /etc/httpd/conf.d/remoteip.conf
+
 # Install redis for PHP session handling and common caching
 # https://github.com/phpredis/phpredis/blob/develop/INSTALL.markdown
 RUN set -ex; \


### PR DESCRIPTION
## Summary

Configures Apache's `mod_remoteip` module to properly handle X-Forwarded-For headers when running behind reverse proxies (OpenShift router, load balancers, etc.).

## Changes

Added remoteip configuration to all three Containerfiles:
- ✅ Containerfile.ubi8
- ✅ Containerfile.ubi9
- ✅ Containerfile.ubi10

Each creates `/etc/httpd/conf.d/remoteip.conf` with:
- `RemoteIPHeader X-Forwarded-For` - Use the X-Forwarded-For header for client IP
- Trusted proxy IP ranges for private networks (Kubernetes/OpenShift environments):
  - `10.0.0.0/8` - Kubernetes pod/service networks
  - `172.16.0.0/12` - Docker/container networks
  - `192.168.0.0/16` - Private networks
  - `169.254.0.0/16` - Link-local addresses
  - `127.0.0.0/8` - Localhost

## Why This Matters

When PHP applications run behind a reverse proxy (common in OpenShift/Kubernetes), the `$_SERVER['REMOTE_ADDR']` variable contains the proxy's IP address, not the real client's IP. This configuration:

1. Tells Apache to trust X-Forwarded-For headers from specified proxy IP ranges
2. Updates REMOTE_ADDR to contain the real client IP
3. Enables proper logging, rate limiting, and geolocation in PHP applications

## Verification

After images are built, the configuration can be verified:

```bash
podman run --rm quay.io/cuppett/ubi-php:83-ubi10 cat /etc/httpd/conf.d/remoteip.conf
podman run --rm quay.io/cuppett/ubi-php:83-ubi10 httpd -M | grep remoteip
```

## References

- Apache mod_remoteip docs: https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
- Inspiration: https://github.com/docker-library/wordpress/blob/master/latest/php8.3/apache/Dockerfile#L107-L121

Addresses #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)